### PR TITLE
erlang:get_stacktrace/0 removed as it should be called in a catch

### DIFF
--- a/src/erlimem_cmds.erl
+++ b/src/erlimem_cmds.erl
@@ -95,6 +95,8 @@ recv_sync({Mod, Sock}, Bin, Len) when Mod =:= ssl; Mod =:= gen_tcp ->
         end;
     {error, Reason} ->
         ?Error("~p tcp error ~p", [?MODULE, Reason]),
-        ?Error("~p tcp error stack :~n~p~n", [?MODULE, erlang:get_stacktrace()]),
-        throw({{error, Reason}, erlang:get_stacktrace()})
+        % throw({{error, Reason}, [erlang:get_stacktrace()]})
+        % erlang:stacktrace/0 cannot be called outside catch
+        % so to keep the interface the same returning empty list
+        throw({{error, Reason}, []})
     end.


### PR DESCRIPTION
removed erl_20 compile time warnings
```
Warning: erlang:get_stacktrace/0 used following an old-style 'catch' may stop working in a future release. (Use it inside 'try'.)
Warning: erlang:get_stacktrace/0 used following an old-style 'catch' may stop working in a future release. (Use it inside 'try'.)
```